### PR TITLE
modelListガード節をStringBuilder作成後に移動

### DIFF
--- a/contents/066/answer/README.md
+++ b/contents/066/answer/README.md
@@ -17,14 +17,14 @@ public class Knock066 {
     private Knock066() {};
 
     public static String convertToString(List<Model> modelList) {
-        // modelListがnullでないことを保証. #1
-        if (modelList == null) {
-            return result;
-        }
-        
         //String result = "";
         StringBuilder result = new StringBuilder(); // 修正箇所. #4
-        
+
+        // modelListがnullでないことを保証. #1
+        if (modelList == null) {
+            return result.toString();
+        }
+               
         for (Model model : modelList) {
             // Modelオブジェクトがnullの場合はスキップ. #2
             if (model != null) {


### PR DESCRIPTION
modelListがnullの場合の処理について、result定義前に使用していたので位置を移動しました。
そのままの位置でnullか空文字を返却することも検討しましたが、将来的にresultのインスタンスを変更した場合を考え、modelListがnullでない場合と処理を合わせました。
ご確認よろしくお願いいたします。